### PR TITLE
Clean up custom namedtuples and handling Windows

### DIFF
--- a/lmdb_python/_cython/msvcrt.pxd
+++ b/lmdb_python/_cython/msvcrt.pxd
@@ -1,0 +1,5 @@
+cdef extern from "STDDEF.H":
+    ctypedef extern long long intptr_t
+
+cdef extern int _open_osfhandle(intptr_t osfhandle, int flags)
+cdef extern intptr_t _get_osfhandle(int fd)

--- a/lmdb_python/types.py
+++ b/lmdb_python/types.py
@@ -1,0 +1,48 @@
+from collections import namedtuple
+
+
+LmdbStat = namedtuple(
+    "LmdbStat", [
+        "ms_psize",
+        "ms_depth",
+        "ms_branch_pages",
+        "ms_leaf_pages",
+        "ms_overflow_pages",
+        "ms_entries",
+    ]
+)
+LmdbEnvInfo = namedtuple(
+    "LmdbEnvInfo", [
+        "me_mapsize",
+        "me_last_pgno",
+        "me_last_txnid",
+        "me_maxreaders",
+        "me_numreaders",
+    ]
+)
+LmdbEnvFlags = namedtuple(
+    "LmdbEnvFlags", [
+        "fixed_map",
+        "no_subdir",
+        "read_only",
+        "write_map",
+        "no_meta_sync",
+        "no_sync",
+        "map_async",
+        "no_tls",
+        "no_lock",
+        "no_readahead",
+        "no_meminit",
+    ]
+)
+LmdbDbFlags = namedtuple(
+    "LmdbDbFlags", [
+        "reverse_key",
+        "duplicate_sort",
+        "integer_key",
+        "duplicate_fixed",
+        "integer_duplicate",
+        "reverse_duplicate",
+        "creat",
+    ]
+)


### PR DESCRIPTION
Closes #11 
- Move custom namedtuples to a separate `types.py` file so that Python can access them too
- Directly use MSVCRT on Windows, instead of CPython msvcrt package
- All platform checks are done using Cython's conditional compilation (IF ... ELSE ...)