### PR TITLE
Set up index page for pip installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - .github/**
+      - docs/**
       - README.md
       - .gitignore
       - .gitmodules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
       - README.md
       - .gitignore
       - .gitmodules
+      - update_index.py
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -10,16 +10,26 @@ This repo serves as a practice for me to learn how to use 3rd-party C/C++ librar
 
 ## Installation
 
-From wheels: To be provided
+From wheels:
 
-Pre-built wheels matrix
+```bash
+pip install lmdb-python -f https://gau-nernst.github.io/lmdb-python/
+```
 
-Python version | Linux (x86_64 and aarch64) | macOS (universal2) | Windows (x86_64 only)
+The following pre-built wheels are provided (64-bit only)
+
+Python version | Linux | macOS | Windows
 --|--|--|--
-3.7 | ✅ | ✅ (x86_64 only) | ✅ 
+3.7 | ✅ | ✅ | ✅ 
 3.8 | ✅ | ✅ | ✅
 3.9 | ✅ | ✅ | ✅
 3.10 | ✅ | ✅ | ✅
+
+OS | Platform
+---|---------
+Linux | x86_64 and aarch64 (manylinux2014 only, musllinux is not available)
+macOS | universal2 (supports both Intel Mac and Apple Silicon Mac), except Python 3.7, where only Intel Mac is supported
+Windows | x86_64 only
 
 From source: Install directly from this GitHub repo
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl</a>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
 <body>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-win_amd64.whl">lmdb_python-0.0.1-cp310-cp310-win_amd64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl">lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-win_amd64.whl">lmdb_python-0.0.1-cp38-cp38-win_amd64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
-    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-win_amd64.whl">lmdb_python-0.0.1-cp310-cp310-win_amd64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl">lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-win_amd64.whl">lmdb_python-0.0.1-cp38-cp38-win_amd64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a><br>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a><br>
     <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-win_amd64.whl">lmdb_python-0.0.1-cp39-cp39-win_amd64.whl</a>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <body>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp310-cp310-macosx_10_9_universal2.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp310-cp310-win_amd64.whl">lmdb_python-0.0.1-cp310-cp310-win_amd64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-macosx_10_9_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl">lmdb_python-0.0.1-cp37-cp37m-win_amd64.whl</a>
     <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp38-cp38-macosx_10_9_universal2.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp38-cp38-win_amd64.whl">lmdb_python-0.0.1-cp38-cp38-win_amd64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl">lmdb_python-0.0.1-cp39-cp39-macosx_10_9_universal2.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl">lmdb_python-0.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl</a>
+    <a href="https://github.com/gau-nernst/lmdb-python/releases/download/0.0.1/lmdb_python-0.0.1-cp39-cp39-win_amd64.whl">lmdb_python-0.0.1-cp39-cp39-win_amd64.whl</a>
 </body>
 </html>

--- a/update_index.py
+++ b/update_index.py
@@ -1,0 +1,25 @@
+import json
+import urllib.request
+
+index_template = "<!DOCTYPE html>\n<html>\n<body>\n{}\n</body>\n</html>\n"
+
+
+def update_index(url: str, save_path: str):
+    files = []
+    with urllib.request.urlopen(url) as resp:
+        releases = json.load(resp)
+
+    for release in releases:
+        for asset in release["assets"]:
+            wheel_url = asset["browser_download_url"]
+            wheel_name = asset["name"]
+            files.append(f'    <a href="{wheel_url}">{wheel_name}</a>')
+
+    with open(save_path, "w") as f:
+        f.write(index_template.format("\n".join(files)))
+
+
+if __name__ == "__main__":
+    url = "https://api.github.com/repos/gau-nernst/lmdb-python/releases"
+    index_path = "docs/index.html"
+    update_index(url, index_path)

--- a/update_index.py
+++ b/update_index.py
@@ -16,7 +16,7 @@ def update_index(url: str, save_path: str):
             files.append(f'    <a href="{wheel_url}">{wheel_name}</a>')
 
     with open(save_path, "w") as f:
-        f.write(index_template.format("\n".join(files)))
+        f.write(index_template.format("<br>\n".join(files)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #23 

`update_index.py` can be used to generate the index page. Currently updating the index page is not integrated with GHA when a new release is created.